### PR TITLE
Document Custom GPT integration steps

### DIFF
--- a/Master_json/README.md
+++ b/Master_json/README.md
@@ -1,0 +1,65 @@
+# Abang Oky ORCID Custom GPT Action
+
+Dokumen ini menjelaskan bagaimana konfigurasi `gpt_custom_action_schema.json` bekerja ketika digunakan di Custom GPT milik Abang Oky.
+
+## Alur Eksekusi
+1. **Inisiasi Aksi** – GPT akan memilih aksi "Abang Oky ORCID Scholar" ketika membutuhkan data profil publik peneliti.
+2. **Permintaan OAuth** – GPT mengarahkan pengguna ke `https://orcid.org/oauth/authorize` menggunakan Client ID aplikasi Abang Oky. Setelah pengguna login dan menyetujui cakupan `/read-public`, ORCID mengembalikan kode otorisasi ke salah satu URI pengalihan yang terdaftar (mis. `https://chatgpt.com/g/g-68d5b9c669c08191a513e9d75bc85c4e-abang-oky-ai`).
+3. **Penukaran Token** – GPT menukar kode otorisasi tersebut ke `https://orcid.org/oauth/token` untuk mendapatkan `access_token` yang valid beserta ORCID iD pengguna.
+4. **Pemanggilan API** – Dengan token itu, GPT memanggil endpoint `GET /{orcid_id}/record` pada `https://pub.orcid.org/v3.0` untuk mengambil data publik ORCID dalam format JSON.
+5. **Pengolahan Jawaban** – GPT membaca struktur respons (seperti nama, biografi, dan ringkasan aktivitas) lalu merangkumnya agar sesuai dengan konteks bimbingan akademik yang diminta pengguna.
+
+## Fungsi yang Disediakan
+- **`getOrcidProfile`**: Mengambil profil publik lengkap untuk satu ORCID iD. Endpoint ini berada di bagian `paths` file manifest dan membutuhkan parameter `orcid_id` berbentuk `0000-0000-0000-0000`.
+
+## Hal yang Perlu Disiapkan
+- Pastikan Client ID dan Client Secret yang diberikan ORCID tersimpan di konfigurasi Custom GPT ketika menautkan aksi.
+- Semua URI pengalihan yang akan digunakan sudah terdaftar di dashboard ORCID agar proses login berhasil.
+- Logo, URL legal, dan kebijakan privasi pada manifest mengarah ke halaman publik GPT yang sama sehingga memenuhi persyaratan Custom GPT.
+
+Dengan alur di atas, GPT dapat memanfaatkan data ORCID resmi untuk membantu bimbingan akademik tanpa harus menangani data sensitif secara langsung.
+
+## Cara Menghubungkan ke Custom GPT
+Ikuti langkah berikut agar manifest dapat digunakan langsung di aksi Custom GPT Anda:
+
+1. **Unggah Manifest** – Pada halaman pengaturan Custom GPT, pilih tab *Actions* lalu klik *Import from URL/Upload*. Seret file `gpt_custom_action_schema.json` ini atau unggah melalui GitHub Raw sehingga struktur OAuth dan OpenAPI terbaca otomatis.
+2. **Isi Kredensial OAuth** – Masukkan `Client ID` dan `Client Secret` ORCID yang aktif (sandbox atau produksi). Pastikan nilai tersebut sama dengan yang terdaftar pada dashboard ORCID aplikasi Anda.
+3. **Tetapkan Redirect URI** – Gunakan salah satu URI pengalihan yang sudah didaftarkan di ORCID (mis. `https://chatgpt.com/g/g-68d5b9c669c08191a513e9d75bc85c4e-abang-oky-ai`). URI inilah yang harus dimasukkan saat konfigurasi aksi Custom GPT.
+4. **Simpan dan Uji** – Setelah semua bidang terisi, klik *Save* dan jalankan percakapan percobaan. Jika proses OAuth berhasil, GPT akan dapat memicu fungsi `getOrcidProfile` dan menampilkan ringkasan profil ORCID pengguna.
+
+## Panduan Pengujian
+Gunakan langkah berikut untuk memastikan konfigurasi bekerja sebelum dipasang ke Custom GPT produksi:
+
+1. **Validasi Manifest**  
+   Jalankan perintah berikut di repositori ini untuk memastikan file JSON valid:
+   ```bash
+   jq empty Master_json/gpt_custom_action_schema.json
+   ```
+
+2. **Uji Alur OAuth di Sandbox**  
+   a. Buka URL otorisasi dan ganti `REDIRECT_URI` sesuai yang terdaftar di dashboard ORCID:  
+   `https://sandbox.orcid.org/oauth/authorize?client_id=APP-XXXXX&response_type=code&scope=/read-public&redirect_uri=REDIRECT_URI`
+
+   b. Setelah login, ORCID akan mengarahkan ke URI pengalihan sambil membawa parameter `code`. Simpan nilai tersebut.
+
+   c. Tukarkan `code` menjadi `access_token` menggunakan `curl` berikut (ganti placeholder sesuai kredensial sandbox Anda):
+   ```bash
+   curl -i -L -H "Accept: application/json" \
+     --data "client_id=APP-XXXXX" \
+     --data "client_secret=CLIENT_SECRET" \
+     --data "grant_type=authorization_code" \
+     --data "redirect_uri=REDIRECT_URI" \
+     --data "code=AUTH_CODE" \
+     https://sandbox.orcid.org/oauth/token
+   ```
+
+3. **Verifikasi Endpoint ORCID**  
+   Ambil profil publik menggunakan token yang diterima pada langkah sebelumnya:
+   ```bash
+   curl -H "Accept: application/json" \
+     -H "Authorization: Bearer ACCESS_TOKEN" \
+     https://pub.sandbox.orcid.org/v3.0/0000-0000-0000-0000/record
+   ```
+
+4. **Konfirmasi di Custom GPT**  
+   Setelah tes sandbox berhasil, masukkan Client ID, Client Secret, dan URI pengalihan produksi ke pengaturan aksi Custom GPT, lalu lakukan percakapan percobaan untuk memastikan GPT dapat memicu aksi dan merangkum data ORCID yang diambil.

--- a/Master_json/gpt_custom_action_schema.json
+++ b/Master_json/gpt_custom_action_schema.json
@@ -1,0 +1,299 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Abang Oky ORCID Scholar",
+  "name_for_model": "abang_oky_orcid_scholar",
+  "description_for_human": "Bimbingan akademik Safwa University dengan akses data ORCID untuk karya tulis ilmiah.",
+  "description_for_model": "Use this to authenticate with ORCID on behalf of Safwa University students, retrieve public ORCID profiles, and summarize works relevant to Islamic education and management research.",
+  "contact_email": "support@safwauniversity.ac.id",
+  "legal_info_url": "https://chatgpt.com/g/g-68d5b9c669c08191a513e9d75bc85c4e-abang-oky-ai",
+  "privacy_policy_url": "https://chatgpt.com/g/g-68d5b9c669c08191a513e9d75bc85c4e-abang-oky-ai",
+  "logo_url": "https://chatgpt.com/g/g-68d5b9c669c08191a513e9d75bc85c4e-abang-oky-ai.png",
+  "auth": {
+    "type": "oauth",
+    "client_url": "https://chatgpt.com/g/g-68d5b9c669c08191a513e9d75bc85c4e-abang-oky-ai",
+    "authorization_url": "https://orcid.org/oauth/authorize",
+    "token_url": "https://orcid.org/oauth/token",
+    "refresh_url": "https://orcid.org/oauth/token",
+    "scopes": [
+      "/read-public"
+    ],
+    "authorization_content_type": "application/x-www-form-urlencoded",
+    "verification_tokens": {}
+  },
+  "api": {
+    "type": "openapi",
+    "spec": {
+      "openapi": "3.1.0",
+      "info": {
+        "title": "Abang Oky ORCID Integration API",
+        "description": "Endpoints used by the Abang Oky GPT action to retrieve public ORCID profile information after OAuth authentication.",
+        "version": "1.0.0"
+      },
+      "servers": [
+        {
+          "url": "https://pub.orcid.org/v3.0"
+        }
+      ],
+      "paths": {
+        "/{orcid_id}/record": {
+          "get": {
+            "operationId": "getOrcidProfile",
+            "summary": "Ambil profil ORCID",
+            "description": "Mengambil catatan publik ORCID milik peneliti untuk keperluan pembimbingan karya tulis.",
+            "parameters": [
+              {
+                "name": "orcid_id",
+                "in": "path",
+                "required": true,
+                "schema": {
+                  "type": "string",
+                  "pattern": "^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$"
+                },
+                "description": "ORCID iD lengkap dalam format 0000-0000-0000-0000."
+              },
+              {
+                "name": "Accept",
+                "in": "header",
+                "required": false,
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "application/json"
+                  ]
+                },
+                "description": "Header opsional untuk memastikan respons JSON."
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Profil publik ORCID",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/OrcidRecord"
+                    }
+                  }
+                }
+              },
+              "401": {
+                "description": "Token akses tidak valid atau kedaluwarsa"
+              },
+              "404": {
+                "description": "Profil tidak ditemukan"
+              }
+            },
+            "security": [
+              {
+                "OAuth2": [
+                  "/read-public"
+                ]
+              }
+            ]
+          }
+        }
+      },
+      "components": {
+        "securitySchemes": {
+          "OAuth2": {
+            "type": "oauth2",
+            "flows": {
+              "authorizationCode": {
+                "authorizationUrl": "https://orcid.org/oauth/authorize",
+                "tokenUrl": "https://orcid.org/oauth/token",
+                "scopes": {
+                  "/read-public": "Mengakses data profil publik ORCID"
+                }
+              }
+            }
+          }
+        },
+        "schemas": {
+          "OrcidRecord": {
+            "type": "object",
+            "properties": {
+              "orcid-identifier": {
+                "type": "object",
+                "properties": {
+                  "uri": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "path": {
+                    "type": "string"
+                  }
+                }
+              },
+              "person": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "object",
+                    "properties": {
+                      "given-names": {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "family-name": {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "biography": {
+                    "type": "object",
+                    "properties": {
+                      "content": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "activities-summary": {
+                "type": "object",
+                "properties": {
+                  "educations": {
+                    "type": "object",
+                    "properties": {
+                      "education-summary": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "role-title": {
+                              "type": "string"
+                            },
+                            "organization": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "employments": {
+                    "type": "object",
+                    "properties": {
+                      "employment-summary": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "role-title": {
+                              "type": "string"
+                            },
+                            "organization": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "works": {
+                    "type": "object",
+                    "properties": {
+                      "group": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "work-summary": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "title": {
+                                    "type": "object",
+                                    "properties": {
+                                      "title": {
+                                        "type": "object",
+                                        "properties": {
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "journal-title": {
+                                    "type": "object",
+                                    "properties": {
+                                      "value": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "external-ids": {
+                                    "type": "object",
+                                    "properties": {
+                                      "external-id": {
+                                        "type": "array",
+                                        "items": {
+                                          "type": "object",
+                                          "properties": {
+                                            "external-id-url": {
+                                              "type": "object",
+                                              "properties": {
+                                                "value": {
+                                                  "type": "string",
+                                                  "format": "uri"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    }
+                                  },
+                                  "publication-date": {
+                                    "type": "object",
+                                    "properties": {
+                                      "year": {
+                                        "type": "object",
+                                        "properties": {
+                                          "value": {
+                                            "type": "string"
+                                          }
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "ui": {
+    "default_open": false
+  }
+}


### PR DESCRIPTION
## Summary
- add a Custom GPT integration section that explains how to upload the manifest, supply ORCID OAuth credentials, and verify redirect URIs
- clarify that saving the action enables the getOrcidProfile endpoint once OAuth succeeds

## Testing
- `jq empty Master_json/gpt_custom_action_schema.json`


------
https://chatgpt.com/codex/tasks/task_e_68dc0d9a3000832088415a32812669a5